### PR TITLE
fixed runGOforDESeq2.R to grep output names for no sig terms

### DIFF
--- a/scripts/runGOforDESeq2.R
+++ b/scripts/runGOforDESeq2.R
@@ -147,7 +147,7 @@ go.UP.BP <- runGO(geneList=up.geneList,xx=xx,otype="BP",setName=paste(basename(c
 drawBarplot(go=go.UP.BP,ontology="BP",setName=paste(basename(comparison),"upFC",FC, "adjp", adjp, sep="."))
 
 }else{
-up_out = snakemake@output[[1]]
+up_out = snakemake@output[[grep("diffexp.upFC", snakemake@output)]]
 write.table('No Significant Genes', file=up_out)
 }
 
@@ -171,6 +171,6 @@ print("make barplot for down genes")
 drawBarplot(go=go.DN.BP,ontology="BP",setName=paste(basename(comparison),"downFC",FC, "adjp", adjp, sep="."))
 
 }else{
-down_out = snakemake@output[[2]]
+down_out = snakemake@output[[grep("diffexp.downFC", snakemake@output)]]
 write.table('No Significant Gene', file=down_out)
 }


### PR DESCRIPTION
When debugging an error, I found that when there are no significant genes for down regulated genes that it was hard coded to save the no significant terms message to the wrong output file, which over wrote the up regulated genes terms. This was also the case in the unregulated genes. This will effect anyone who previously ran the pipeline and did not have any significant terms for only one direction of the differentially expressed genes. I changed the commands to look for the right output files `up_out = snakemake@output[[grep("diffexp.upFC", snakemake@output)]]` & `down_out = snakemake@output[[grep("diffexp.downFC", snakemake@output)]]`